### PR TITLE
security: pin GitHub Actions to commit hashes

### DIFF
--- a/.github/actions/post-comment/action.yaml
+++ b/.github/actions/post-comment/action.yaml
@@ -29,7 +29,7 @@ runs:
       run: echo "value=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
 
     - name: Post comment
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       env:
         COMMENT_TITLE: ${{ inputs.title }}
         COMMENT_CONTENT: ${{ inputs.content }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
@@ -72,15 +72,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Create e2e checklist
         id: e2e-tasks
@@ -57,7 +57,7 @@ jobs:
       number: ${{ github.event.issue.number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Check task status
         id: e2e-tasks
@@ -155,7 +155,7 @@ jobs:
 
       - name: Close completed E2E issue
         if: ${{ steps.e2e-tasks.outputs.all-checked == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.issues.update({
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Create basic checklist
         if: needs.execute-e2e-tasks.outputs.should-run-e2e == 'true'
@@ -273,7 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Get workflow files
         id: workflow-files
@@ -408,7 +408,7 @@ jobs:
 
       - name: Upload artifact
         if: ${{ steps.file-status.outputs.retrieved == 'true' && steps.file-status.outputs.changed == 'true' && fromJSON(steps.file-status.outputs.state).download && steps.create-artifact.outputs.has-selected-files == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: issue-${{ needs.execute-e2e-tasks.outputs.number || github.event.issue.number }}-workflows-${{ steps.create-artifact.outputs.timestamp }}
           path: selected-files/
@@ -481,7 +481,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Create demo checklist
         if: needs.execute-e2e-tasks.outputs.should-run-e2e == 'true'
@@ -513,7 +513,7 @@ jobs:
 
       - name: Display state retrieval results
         if: ${{ steps.state-check.outputs.retrieved == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const checkedState = JSON.parse('${{ steps.state-check.outputs.state }}');
@@ -599,7 +599,7 @@ jobs:
       - name: Handle workflow failures
         id: handle-workflow-failures
         if: needs.basic-workflow-test.result == 'failure' || needs.dynamic-workflow-test.result == 'failure' || needs.state-retrieval-test.result == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const basicStatus = '${{ needs.basic-workflow-test.result }}';


### PR DESCRIPTION
## Summary

This PR enhances security by pinning all GitHub Actions dependencies to their specific commit hashes instead of using semantic version tags.

## Changes

- **actions/checkout**: `v5` → `v5.0.0` (08c6903cd8c0fde910a37f88322edcfb5dd907a8)
- **actions/setup-node**: `v5` → `v5.0.0` (a0853c24544627f65ddf259abe73b1d18a591444)
- **pnpm/action-setup**: `v4` → `v4.1.0` (a7487c7e89a18df4991f7f222e4898a00d66ddda)
- **actions/github-script**: `v7` → `v7.1.0` (f28e40c7f34bde8b3046d885e986cb6290c5673b)
- **actions/upload-artifact**: `v4` → `v4.6.2` (ea165f8d65b6e75b540449e92b4886f43607fa02)

## Security Benefits

- **Immutable References**: Commit hashes cannot be changed, unlike tags which can be moved
- **Supply Chain Protection**: Prevents potential tag manipulation attacks
- **Reproducible Builds**: Ensures exact same action versions across all workflow runs
- **Industry Best Practice**: Follows security guidelines for CI/CD pipelines

All pinned versions include comments with the semantic version for maintainability and easy identification of the original version being used.